### PR TITLE
Simplify TaggedProviderTrait::filterListenersForEvent()

### DIFF
--- a/src/TaggedProviderTrait.php
+++ b/src/TaggedProviderTrait.php
@@ -107,10 +107,8 @@ trait TaggedProviderTrait
     protected function filterListenersForEvent(object $event, iterable $listenerSet) : iterable
     {
         foreach ($listenerSet as $type => $listeners) {
-            foreach ($listeners as $listener) {
-                if ($event instanceof $type) {
-                    yield $listener;
-                }
+            if ($event instanceof $type) {
+                yield from $listeners;
             }
         }
     }


### PR DESCRIPTION
It's not necessary to check the event type within the inner loop.
Moving the condition up allows to `yield from` instead.