### PR TITLE
Simplify Parameter deriver logic.

### DIFF
--- a/src/ParameterDeriverTrait.php
+++ b/src/ParameterDeriverTrait.php
@@ -11,6 +11,10 @@ trait ParameterDeriverTrait
     /**
      * Derives the class type of the first argument of a callable.
      *
+     * If the callable is an array, referring to a method or static method, of an object
+     * that is not yet defined then it may fail a callable check even if it will be callable later.
+     * We therefore have to skip type hinting the parameter to avoid it failing in some edge cases.
+     *
      * @param callable $callable
      *   The callable for which we want the parameter type.
      * @return string
@@ -18,8 +22,6 @@ trait ParameterDeriverTrait
      */
     protected function getParameterType($callable) : string
     {
-        // We can't type hint $callable as it could be an array, and arrays are not callable. Sometimes. Bah, PHP.
-
         // This try-catch is only here to keep OCD linters happy about uncaught reflection exceptions.
         try {
             // See the docblock of isClassCallable() for why this needs to come first.

--- a/src/ParameterDeriverTrait.php
+++ b/src/ParameterDeriverTrait.php
@@ -22,26 +22,13 @@ trait ParameterDeriverTrait
 
         // This try-catch is only here to keep OCD linters happy about uncaught reflection exceptions.
         try {
-            switch (true) {
-                // See note on isClassCallable() for why this must be the first case.
-                case $this->isClassCallable($callable):
-                    $reflect = new \ReflectionClass($callable[0]);
-                    $params = $reflect->getMethod($callable[1])->getParameters();
-                    break;
-                case $this->isFunctionCallable($callable):
-                case $this->isClosureCallable($callable):
-                    $reflect = new \ReflectionFunction($callable);
-                    $params = $reflect->getParameters();
-                    break;
-                case $this->isObjectCallable($callable):
-                    $reflect = new \ReflectionObject($callable[0]);
-                    $params = $reflect->getMethod($callable[1])->getParameters();
-                    break;
-                case $this->isInvokable($callable):
-                    $params = (new \ReflectionMethod($callable, '__invoke'))->getParameters();
-                    break;
-                default:
-                    throw new \InvalidArgumentException('Not a recognized type of callable');
+            // See the docblock of isClassCallable() for why this needs to come first.
+            if ($this->isClassCallable($callable)) {
+                $reflect = new \ReflectionClass($callable[0]);
+                $params = $reflect->getMethod($callable[1])->getParameters();
+            } else {
+                $reflect = new \ReflectionFunction(\Closure::fromCallable($callable));
+                $params = $reflect->getParameters();
             }
 
             $rType = $params[0]->getType();
@@ -62,6 +49,8 @@ trait ParameterDeriverTrait
      *
      * Or at least a reasonable approximation, since a function name may not be defined yet.
      *
+     * @deprecated No longer necessary so will be removed at some point in the future.
+     *
      * @param callable $callable
      * @return True if the callable represents a function, false otherwise.
      */
@@ -74,6 +63,8 @@ trait ParameterDeriverTrait
     /**
      * Determines if a callable represents a closure/anonymous function.
      *
+     * @deprecated No longer necessary so will be removed at some point in the future.
+     *
      * @param callable $callable
      * @return True if the callable represents a closure object, false otherwise.
      */
@@ -84,6 +75,8 @@ trait ParameterDeriverTrait
 
     /**
      * Determines if a callable represents a method on an object.
+     *
+     * @deprecated No longer necessary so will be removed at some point in the future.
      *
      * @param callable $callable
      * @return True if the callable represents a method object, false otherwise.
@@ -102,9 +95,8 @@ trait ParameterDeriverTrait
      * an array is still not technically callable.  Omitting the parameter type here
      * allows us to use this method to handle both cases.
      *
-     * Note that this method must therefore be the first in the switch statement
-     * above, or else subsequent calls will break as the array is not going to satisfy
-     * the callable type hint but it would pass `is_callable()`.  Because PHP.
+     * This method must therefore be called first above, as the array is not actually
+     * an `is_callable()` and will fail `Closure::fromCallable()`.  Because PHP.
      *
      * @param callable $callable
      * @return True if the callable represents a static method, false otherwise.
@@ -116,6 +108,8 @@ trait ParameterDeriverTrait
 
     /**
      * Determines if a callable is a class that has __invoke() method
+     *
+     * @deprecated No longer necessary so will be removed at some point in the future.
      *
      * @param callable $callable
      * @return True if the callable represents an invokable object, false otherwise.


### PR DESCRIPTION
Closure::fromCallable() works for all but one case, so just use that most of the time.

I am not removing the rest of the methods as they're protected, and someone might be using them.  They are marked as deprecated, though, so if you're still using those, stop.  They'll get killed in the next major version, probably.