### PR TITLE
Add test case to illustrate how to properly match against "any object"

### DIFF
--- a/tests/InvokableAnyObject.php
+++ b/tests/InvokableAnyObject.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Fig\EventDispatcher;
+
+class InvokableAnyObject
+{
+    public function __invoke(object $event)
+    {
+        // do nothing
+    }
+}

--- a/tests/ParameterDeriverTest.php
+++ b/tests/ParameterDeriverTest.php
@@ -72,4 +72,12 @@ class ParameterDeriverTest extends TestCase
 
         $this->assertEquals(Foo::class, $type);
     }
+
+    public function test_derive_any_invokable() : void
+    {
+        $type = $this->deriver->getParameterType(new InvokableAnyObject());
+
+        $this->assertEquals('object', $type);
+
+    }
 }


### PR DESCRIPTION
It's not really about a bug in the trait - it works as designed.
However, you cannot import object to the current namespace and you must not qualify a type hint against object either.
This lead to a bug in my ListenerProvider implementation and I thought it would be handy to have this unit test as an illustration of how to use this edge case.
